### PR TITLE
Add optional positional arg (crate name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ $ cargo breaking
 Next version is: 3.0.0
 ```
 
+### Args
+
+`against`, an arg to specify the github ref (a tag, a branch name or a commit) against which we can compare our current crate version.
+- use:
+```none
+cargo breaking -a branch_name
+```
+- default: "main"
+
 ## Goals and non goals
 
 `cargo-breaking` aims to detect most breaking changes, but deliberately chooses

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,10 @@ impl ProgramConfig {
             .author(crate_authors!())
             .about(crate_description!())
             .arg(
+                Arg::with_name("crate_name")
+                    .required(false)
+            )
+            .arg(
                 Arg::with_name("against")
                     .short("a")
                     .help("Sets the git reference to compare the API against. Can be a tag, a branch name or a commit.")


### PR DESCRIPTION
Not the cleanest way imo, but the builder doesn't seem to allow us to do it explicitely.
Here's how to handle other positional args (FYI) :
![image](https://user-images.githubusercontent.com/13097851/125101809-eb4b3900-e0da-11eb-9edf-d521122861b9.png)
