### PR TITLE
Make integration tests compile

### DIFF
--- a/src/comparator/utils.rs
+++ b/src/comparator/utils.rs
@@ -1,22 +1,15 @@
 use std::{
     path::{Path, PathBuf},
-    process::Command,
 };
 
-use anyhow::{anyhow, ensure, Context, Result as AnyResult};
-use semver::Version;
+use anyhow::{ensure, Context, Result as AnyResult};
 use tempfile::TempDir;
-
-use rustc_driver::{Callbacks, RunCompiler};
-use rustc_interface::Config;
-use rustc_session::config::Input;
-use rustc_span::FileName;
 
 pub(crate) const PREVIOUS_CRATE_NAME: &str = "previous";
 pub(crate) const NEXT_CRATE_NAME: &str = "next";
 
 use crate::{
-    compiler::{Change, ChangeSet, Compiler, InstrumentedCompiler, StandardCompiler},
+    compiler::{ChangeSet, Compiler, InstrumentedCompiler, StandardCompiler},
     invocation_settings::GlueCompilerInvocationSettings,
 };
 
@@ -187,12 +180,6 @@ impl<'a> CompilationUnit<'a> {
     }
 
     fn common_args(&self) -> Vec<String> {
-        let out = Command::new("rustc")
-            .arg("--print=sysroot")
-            .current_dir(".")
-            .output()
-            .unwrap();
-
         mk_string_vec! {
             "rustc",
             "--crate-name", self.crate_name,
@@ -213,30 +200,5 @@ impl<'a> CompilationUnit<'a> {
         path.push(format!("lib{}.rmeta", self.crate_name));
 
         path
-    }
-}
-
-fn test_compiler_settings() -> GlueCompilerInvocationSettings {
-    GlueCompilerInvocationSettings {
-        glue_crate_name: "glue".to_string(),
-        previous_crate_name: PREVIOUS_CRATE_NAME.to_string(),
-        next_crate_name: NEXT_CRATE_NAME.to_string(),
-        crate_version: Version::new(0, 0, 0),
-        package_name: "test".to_string(),
-    }
-}
-
-struct DepCompiler {
-    file_name: String,
-    code: String,
-}
-
-impl Callbacks for DepCompiler {
-    fn config(&mut self, config: &mut Config) {
-        // Replace code with contained String
-        config.input = Input::Str {
-            name: FileName::Custom(self.file_name.clone()),
-            input: self.code.clone(),
-        }
     }
 }

--- a/src/comparator/utils.rs
+++ b/src/comparator/utils.rs
@@ -152,10 +152,6 @@ impl<'a> CompilationUnit<'a> {
             "next".to_string(),
         );
 
-        settings
-            .write_to(Path::new(""))
-            .context("Failed to write invocation settings")?;
-
         InstrumentedCompiler::faked(
             "glue".to_owned(),
             format!(
@@ -163,6 +159,7 @@ impl<'a> CompilationUnit<'a> {
                 PREVIOUS_CRATE_NAME, NEXT_CRATE_NAME
             ),
             args,
+            settings,
         )?
         .run()
     }

--- a/src/comparator/utils.rs
+++ b/src/comparator/utils.rs
@@ -1,7 +1,4 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{ensure, Context, Result as AnyResult};
 use tempfile::TempDir;

--- a/src/comparator/utils.rs
+++ b/src/comparator/utils.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     path::{Path, PathBuf},
 };
 

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -5,7 +5,7 @@ fn private_is_not_reported() {
     let diff = compatibility_diagnosis! {
         {},
         {
-            fn fact(n: u32) -> u32 {}
+            fn fact(n: u32) -> u32 { todo!() }
         },
     };
 
@@ -17,7 +17,7 @@ fn addition() {
     let diff = compatibility_diagnosis! {
         {},
         {
-            pub fn fact(n: u32) -> u32 {}
+            pub fn fact(n: u32) -> u32 { todo!() }
         },
     };
 
@@ -70,9 +70,11 @@ fn body_change_not_detected() {
 fn fn_arg_comma_is_removed() {
     let diff = compatibility_diagnosis! {
         {
+            type t = ();
             pub fn a(a: t, b: t, c: t,) {}
         },
         {
+            type t = ();
             pub fn a(a: t, b: t, c: t) {}
         },
     };
@@ -84,9 +86,12 @@ fn fn_arg_comma_is_removed() {
 fn fn_arg_last_character_not_removed() {
     let diff = compatibility_diagnosis! {
         {
+            type t = ();
             pub fn a(a: t, b: t, c: t) {}
         },
         {
+            type t = ();
+            type u = ();
             pub fn a(a: t, b: t, c: u) {}
         },
     };

--- a/tests/method.rs
+++ b/tests/method.rs
@@ -79,45 +79,23 @@ fn signature_change_is_modification() {
 }
 
 #[test]
-fn generic_param_change_is_modification() {
+fn generic_param_change_is_not_reported() {
     let diff = compatibility_diagnosis! {
         {
-            pub struct A;
-            impl<T> A {
+            pub struct A<T>(T);
+            impl<T> A<T> {
                 pub fn f() {}
             }
         },
         {
-            pub struct A;
-            impl<U> A {
+            pub struct A<T>(T);
+            impl<U> A<U> {
                 pub fn f() {}
             }
         }
     };
 
-    assert_eq!(diff.to_string(), "≠ A::f\n");
-}
-
-#[test]
-fn generic_arg_change_is_modification() {
-    let diff = compatibility_diagnosis! {
-        {
-            pub struct A;
-
-            impl A<T> {
-                pub fn f() {}
-            }
-        },
-        {
-            pub struct A;
-
-            impl A<U> {
-                pub fn f() {}
-            }
-        },
-    };
-
-    assert_eq!(diff.to_string(), "≠ A::f\n");
+    assert!(diff.is_empty());
 }
 
 #[test]

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -84,11 +84,14 @@ fn new_public_field_named_is_modification() {
 fn new_private_field_named_is_not_reported() {
     let diff = compatibility_diagnosis! {
         {
+            type b = ();
             pub struct D {
                 a: b,
             }
         },
         {
+            type b = ();
+            type d = ();
             pub struct D {
                 a: b,
                 c: d,
@@ -168,7 +171,7 @@ fn generic_change_is_modification() {
             pub struct E;
         },
         {
-            pub struct E<T>;
+            pub struct E<T>(T);
         },
     };
 

--- a/tests/trait_defs.rs
+++ b/tests/trait_defs.rs
@@ -31,12 +31,12 @@ fn trait_item_modification() {
     let diff = compatibility_diagnosis! {
         {
             pub trait A {
-                type B = u8;
+                type B: ToString;
             }
         },
         {
             pub trait A {
-                type B = u16;
+                type B: Clone;
             }
         },
     };

--- a/tests/trait_impls.rs
+++ b/tests/trait_impls.rs
@@ -4,9 +4,11 @@ use cargo_breaking::compatibility_diagnosis;
 fn addition_simple() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait A {}
             pub struct T;
         },
         {
+            pub trait A {}
             pub struct T;
 
             impl A for T {}
@@ -20,29 +22,37 @@ fn addition_simple() {
 fn modification_simple() {
     let diff = compatibility_diagnosis! {
         {
-            pub struct T;
+            pub trait T {}
+            pub struct S<T>(T);
 
-            impl<A> A for T<A> {}
+            impl<A> T for S<A> {}
         },
         {
-            pub struct T;
+            pub trait T {}
+            pub struct S<T>(T);
 
-            impl<B> A for T<B> {}
+            impl<B> T for S<B> {}
         }
     };
 
-    assert_eq!(diff.to_string(), "≠ T: A\n");
+    assert!(diff.is_empty());
 }
 
 #[test]
 fn provided_method_implementation_is_not_reported() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait T {
+                fn f() {}
+            }
             pub struct S;
 
             impl T for S {}
         },
         {
+            pub trait T {
+                fn f() {}
+            }
             pub struct S;
 
             impl T for S {
@@ -58,6 +68,9 @@ fn provided_method_implementation_is_not_reported() {
 fn constant_modification_is_modification() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait T {
+                const C: usize;
+            }
             pub struct S;
 
             impl T for S {
@@ -65,6 +78,9 @@ fn constant_modification_is_modification() {
             }
         },
         {
+            pub trait T {
+                const C: usize;
+            }
             pub struct S;
 
             impl T for S {
@@ -80,6 +96,9 @@ fn constant_modification_is_modification() {
 fn type_modification_is_modification() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait T {
+                type T;
+            }
             pub struct S;
 
             impl T for S {
@@ -87,6 +106,9 @@ fn type_modification_is_modification() {
             }
         },
         {
+            pub trait T {
+                type T;
+            }
             pub struct S;
 
             impl T for S {
@@ -102,12 +124,16 @@ fn type_modification_is_modification() {
 fn impl_trait_order_is_not_tracked() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait T1 {}
+            pub trait T2 {}
             pub struct S;
 
             impl T1 for S {}
             impl T2 for S {}
         },
         {
+            pub trait T1 {}
+            pub trait T2 {}
             pub struct S;
 
             impl T2 for S {}
@@ -122,11 +148,13 @@ fn impl_trait_order_is_not_tracked() {
 fn not_reported_when_type_is_not_public() {
     let diff = compatibility_diagnosis! {
         {
+            pub trait T {}
             struct S;
 
             impl T for S {}
         },
         {
+            pub trait T {}
             struct S;
         }
     };


### PR DESCRIPTION
I was lazy when writing initial integration tests. As the system worked on the initial AST, i never tried to make the whole thing compile. Now that we're using rustc, our tests must compile. That's what this PR does.

The test still don't pass, but at least they compile :)

Some additional clean-up in the test runner has been performed too.