### PR TITLE
Don't flag functions with user-defined datatypes as changes

### DIFF
--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -12,8 +12,8 @@ use crate::{invocation_settings::GlueCompilerInvocationSettings, public_api::Api
 
 use semver::{BuildMetadata, Prerelease, Version};
 
-use rustc_middle::middle::cstore::ExternCrateSource;
 use rustc_middle::ty::TyCtxt;
+use rustc_session::cstore::ExternCrateSource;
 use rustc_span::def_id::CrateNum;
 
 use crate::{diagnosis::DiagnosisItem, public_api::PublicApi};

--- a/src/public_api.rs
+++ b/src/public_api.rs
@@ -1,5 +1,6 @@
 mod functions;
 mod modules;
+mod utils;
 
 use std::{cmp::Ordering, collections::HashMap};
 
@@ -108,11 +109,12 @@ impl<'tcx> ApiItem<'tcx> {
     }
 
     pub(crate) fn changes_between(
+        tcx: &TyCtxt,
         prev: ApiItem<'tcx>,
         next: ApiItem<'tcx>,
     ) -> Option<Change<'tcx>> {
         match (prev, next) {
-            (ApiItem::Fn(prev), ApiItem::Fn(next)) => FnMetadata::changes_between(prev, next),
+            (ApiItem::Fn(prev), ApiItem::Fn(next)) => FnMetadata::changes_between(tcx, prev, next),
             (ApiItem::Mod(prev), ApiItem::Mod(next)) => ModMetadata::changes_between(prev, next),
 
             _ => unreachable!("Attempt to generate changes for two different-kinded types"),

--- a/src/public_api/utils.rs
+++ b/src/public_api/utils.rs
@@ -1,0 +1,47 @@
+use std::ptr;
+
+use rustc_middle::ty::{self, List, TyCtxt, TyKind};
+
+pub(crate) trait Compare {
+    fn ty_eq(&self, left: ty::Ty, right: ty::Ty) -> bool {
+        ptr::eq(left, right) || self.adt_ty_eq(left, right).unwrap_or_default()
+    }
+
+    fn ty_list_eq(&self, left: &List<ty::Ty>, right: &List<ty::Ty>) -> bool {
+        left == right
+            || (left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right.iter())
+                    .all(|(left, right)| self.ty_eq(left, right)))
+    }
+
+    /// Returns Some(true) if both left and right are ADTs and refer to the same
+    /// type.
+    ///
+    /// Returns Some(false) if both left and right are ADTs but do not refer to
+    /// the same type.
+    ///
+    /// Returns None if at least one of left or right is not an ADT.
+    fn adt_ty_eq(&self, left: ty::Ty, right: ty::Ty) -> Option<bool>;
+}
+
+impl<'tcx> Compare for TyCtxt<'tcx> {
+    fn adt_ty_eq(&self, left: ty::Ty, right: ty::Ty) -> Option<bool> {
+        let left_path = adt_path_of_ty(self, left)?;
+        let right_path = adt_path_of_ty(self, right)?;
+
+        Some(left_path == right_path)
+    }
+}
+
+fn adt_path_of_ty(tcx: &TyCtxt<'_>, ty: ty::Ty) -> Option<String> {
+    let adt_def_id = match ty.kind() {
+        TyKind::Adt(adt, _) => adt.did,
+        _ => return None,
+    };
+
+    let path = tcx.def_path(adt_def_id).to_string_no_crate_verbose();
+
+    Some(path)
+}

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -100,7 +100,7 @@ fn fn_arg_last_character_not_removed() {
 }
 
 #[test]
-fn user_defined_type_change_is_modification() {
+fn user_defined_type_change_is_not_reported() {
     let diff = compatibility_diagnosis! {
         {
             pub struct S;


### PR DESCRIPTION
Previous type equality was performed with `ptr::eq`. It was nice because rustc is built such that "if two types are equal, then they are the same pointer". This is really good for internal compiler development, this not work well here, because the two types may come from the two versions of the crate we're analyzing (ie: `previous::path::to::Type` and `next::path::to::Type`), whichtriggers incorrect modifications in situations such as:

```rust
// Previous:
pub struct S;
pub fn f(_: S) {}

// Next
pub struct S;
pub fn f(_: S) {}
```

This PR fixes this behaviour by adding a custom equality implementation. The idea is simple: if `ptr::eq` returns false, then we check if the two types are ADTs or not. If this is the case, we compare their paths. This solution is maybe not future-proof, but it works well for now. These functions will make easier the handling of other languages items such as struct/enum.

Fix #38.